### PR TITLE
Fixed crn_decomp.h to compile with latest emscripten incoming branch

### DIFF
--- a/crunch/crn_decomp.h
+++ b/crunch/crn_decomp.h
@@ -314,7 +314,6 @@ namespace crnd
 #include <memory.h>
 #else
 #include <malloc.h>
-#include <process.h>
 #endif 
 #include <stdarg.h>
 #include <new> // needed for placement new, _msize, _expand


### PR DESCRIPTION
emscripten just switched its C headers over to musl-libc (see here: https://groups.google.com/forum/#!topic/emscripten-discuss/0ZdaJ4xL8Is), this doesn't come with a process.h (and it looks like the header isn't needed in crn_decomp.h anyway), so I removed it.
