### PR TITLE
Added missing parameter to loadDDSTextureEx call

### DIFF
--- a/texture-util/dds.js
+++ b/texture-util/dds.js
@@ -341,7 +341,7 @@ define([], function () {
      */
     function loadDDSTexture(gl, ext, src, callback) {
         var texture = gl.createTexture();
-        loadDDSTextureEx(gl, src, texture, true, callback);
+        loadDDSTextureEx(gl, ext, src, texture, true, callback);
         return texture;
     }
 


### PR DESCRIPTION
Apparently the extension was not being passed from loadDDSTexture() to loadDDSTextureEx(). This caused the function to try and load a file of src "[object WebGLTexture]" and of course to fail.
