### PR TITLE
Improve bitfield math in dxtToRgb565

### DIFF
--- a/texture-util/dds.js
+++ b/texture-util/dds.js
@@ -158,7 +158,7 @@ define([], function () {
         var m = 0;
         var dstI = 0;
         var i = 0;
-        var r0 = 0, g0 = 0, b0 = 0, r1 = 0, g1 = 0, b1 = 0;
+        var rb0 = 0, g0 = 0, rb1 = 0, g1 = 0;
     
         var blockWidth = width / 4;
         var blockHeight = height / 4;
@@ -167,22 +167,18 @@ define([], function () {
                 i = src16Offset + 4 * (blockY * blockWidth + blockX);
                 c[0] = src[i];
                 c[1] = src[i + 1];
-                r0 = c[0] & 0x1f;
+                rb0 = c[0] & 0xf81f;
                 g0 = c[0] & 0x7e0;
-                b0 = c[0] & 0xf800;
-                r1 = c[1] & 0x1f;
+                rb1 = c[1] & 0xf81f;
                 g1 = c[1] & 0x7e0;
-                b1 = c[1] & 0xf800;
                 // Interpolate between c0 and c1 to get c2 and c3.
                 // Note that we approximate 1/3 as 3/8 and 2/3 as 5/8 for
                 // speed.  This also appears to be what the hardware DXT
                 // decoder in many GPUs does :)
-                c[2] = ((5 * r0 + 3 * r1) >> 3)
-                    | (((5 * g0 + 3 * g1) >> 3) & 0x7e0)
-                    | (((5 * b0 + 3 * b1) >> 3) & 0xf800);
-                c[3] = ((5 * r1 + 3 * r0) >> 3)
-                    | (((5 * g1 + 3 * g0) >> 3) & 0x7e0)
-                    | (((5 * b1 + 3 * b0) >> 3) & 0xf800);
+                c[2] = (((5 * rb0 + 3 * rb1) >> 3) & 0xf81f)
+                     | (((5 * g0 + 3 * g1) >> 3) & 0x7e0);
+                c[3] = (((5 * rb1 + 3 * rb0) >> 3) & 0xf81f)
+                     | (((5 * g1 + 3 * g0) >> 3) & 0x7e0);
                 m = src[i + 2];
                 dstI = (blockY * 4) * width + blockX * 4;
                 dst[dstI] = c[m & 0x3];


### PR DESCRIPTION
As the bitfield math will never extend either further than 3 bits 'up' and there is a 6-bit buffer zone due to the green field in the middle, the red + blue interpolation can be combined, removing decoding and math overhead.